### PR TITLE
Add restoring previous value on `Exceptions` during saving

### DIFF
--- a/lib/src/main/java/dev/burnoo/compose/rememberpreference/RememberPreference.kt
+++ b/lib/src/main/java/dev/burnoo/compose/rememberpreference/RememberPreference.kt
@@ -221,14 +221,19 @@ private inline fun <reified T, reified NNT : T> rememberPreference(
                 is PreferenceEntry.NotEmpty -> currentStateValue.value
             }
             set(value) {
+                val rollbackValue = currentState.value
                 currentState.value = PreferenceEntry.fromNullable(value)
                 coroutineScope.launch {
-                    context.dataStore.edit {
-                        if (value != null) {
-                            it[key] = value as NNT
-                        } else {
-                            it.remove(key)
+                    try {
+                        context.dataStore.edit {
+                            if (value != null) {
+                                it[key] = value as NNT
+                            } else {
+                                it.remove(key)
+                            }
                         }
+                    } catch (e: Exception) {
+                        currentState.value = rollbackValue
                     }
                 }
             }


### PR DESCRIPTION
As mentioned in https://github.com/burnoo/compose-remember-preference/issues/3, currently library is ignoring all `Exceptions` while saving data to `DataStore`.

If decided to implement solution that follows Optimistic UI - library is still displaying its own state, but if any `Exception` occurs, it restores previous value.