### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jetpack Compose library for remembering state persistently, based on DataStore p
 Library is distributed through Maven Central. To use it you need to add following dependancy to your module `build.gradle`:
 ```groovy
 dependencies {
-    implementation 'dev.burnoo:compose-remember-preference:1.0.0'
+    implementation 'dev.burnoo:compose-remember-preference:1.0.1'
 }
 ```
 To store state in `@Composable` when app is running you would use `remember { mutableStateOf(x) }`. The library comes with the same functionality, but supports data persistence, saving and restoring data using DataStore preferences. It has it owns functions that returns `MutableState`.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         lib_version = '1.0.0'
-        compose_version = '1.2.1'
-        compose_compiler_version = '1.3.2'
+        compose_version = '1.4.0'
+        compose_compiler_version = '1.4.4'
         datastore_version = '1.0.0'
     }
     repositories {
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@ plugins {
     id 'maven-publish'
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        lib_version = '1.0.0'
+        lib_version = '1.0.1'
         compose_version = '1.4.0'
         compose_compiler_version = '1.4.4'
         datastore_version = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -38,6 +38,7 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion compose_compiler_version
     }
+    namespace 'dev.burnoo.compose.rememberpreference'
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,7 +9,7 @@ apply from: 'maven-publishing.gradle'
 
 android {
     compileSdk = 33
-    buildToolsVersion = "30.0.3"
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         minSdkVersion 21

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,8 +8,8 @@ plugins {
 apply from: 'maven-publishing.gradle'
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "30.0.3"
+    compileSdk = 33
+    buildToolsVersion = "30.0.3"
 
     defaultConfig {
         minSdkVersion 21

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.burnoo.compose.rememberpreference"/>
+<manifest />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     compileSdk = 33
-    buildToolsVersion = "30.0.3"
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         applicationId "dev.burnoo.compose.rememberpreference.sample"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "30.0.3"
+    compileSdk = 33
+    buildToolsVersion = "30.0.3"
 
     defaultConfig {
         applicationId "dev.burnoo.compose.rememberpreference.sample"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,6 +36,7 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion compose_compiler_version
     }
+    namespace 'dev.burnoo.compose.rememberpreference.sample'
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -42,11 +42,11 @@ dependencies {
 
     implementation project(":lib")
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.activity:activity-compose:1.7.0'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.burnoo.compose.rememberpreference.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
### Changes
- Bump library version to 1.0.1
- Update Gradle Android plugin to 7.4.2
- Update sample libraries
- Update buildToolsVersion to 33.0.1
- Replace deprecated compileSdkVersion and buildToolsVersion Groovy calls
- Replace task to task.register for deleting buildDir
- Update Android Gradle plugin to 7.3.1
- Update Kotlin to 1.8.10, Compose to 1.4.0 and Compose compiler to 1.4.4
